### PR TITLE
Matmat sparse dense

### DIFF
--- a/pyscf/lib/sparsetools/CMakeLists.txt
+++ b/pyscf/lib/sparsetools/CMakeLists.txt
@@ -26,7 +26,7 @@ if ("${BLA_VENDOR}" STREQUAL "INTEL")
 endif()
 
 add_library(sparsetools SHARED
-  m_sparsetools.c m_blas_wrapper.F90
+  m_sparsetools_matvec.cpp m_sparsetools_matmat.cpp m_blas_wrapper.F90
   )
 set_target_properties(sparsetools PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/pyscf/lib/sparsetools/m_sparsetools_matmat.cpp
+++ b/pyscf/lib/sparsetools/m_sparsetools_matmat.cpp
@@ -133,6 +133,7 @@ extern "C" void scsr_spmat_denmat(int nrow_A, int ncol_A, int nnz_A, int *indptr
 
     if (st == fn) {
       indptr_C[i+1] = indptr_C[i];
+      continue;
     }
 
     innz_fn = innz_st + ncol_B;
@@ -171,6 +172,7 @@ extern "C" void dcsr_spmat_denmat(int nrow_A, int ncol_A, int nnz_A, int *indptr
 
     if (st == fn) {
       indptr_C[i+1] = indptr_C[i];
+      continue;
     }
 
     innz_fn = innz_st + ncol_B;

--- a/pyscf/lib/sparsetools/m_sparsetools_matmat.cpp
+++ b/pyscf/lib/sparsetools/m_sparsetools_matmat.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+  
+   Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include<stdio.h>
+#include<stdlib.h>
+#include <omp.h>
+
+extern "C" int count_nnz_spmat_denmat(int nrow, int ncol2, int *indptr)
+{
+
+  int nnz = 0;
+  int i = 0, st = 0, fn = 0;
+
+  for (i = 0; i < nrow; i++) {
+  
+    st = indptr[i];
+    fn = indptr[i+1];
+
+    if (st != fn) {
+      nnz += ncol2;
+    }
+  }
+
+  return nnz;
+}
+
+//template <class I, class T>
+extern "C" void dcsr_matmat(int nrow, int ncol, int nnz, int *Ap, int *Aj, 
+    double *Ax, double *Xx, double *Yx)
+{
+
+  int i, jj;
+  double sum = 0.0;
+
+  # pragma omp parallel \
+  shared (nrow, Yx, Ap, Ax, Xx, Aj) \
+  private (i, jj, sum)
+  {
+    int nthreads = omp_get_num_threads();
+    #pragma omp for schedule(dynamic, (nrow + 4*nthreads-1)/(4*nthreads))
+    for(i = 0; i < nrow; i++){
+      sum = Yx[i];
+      for(jj = Ap[i]; jj < Ap[i+1]; jj++){
+        sum += Ax[jj] * Xx[Aj[jj]];
+      }
+      Yx[i] = sum;
+    }
+  }
+}

--- a/pyscf/lib/sparsetools/m_sparsetools_matmat.cpp
+++ b/pyscf/lib/sparsetools/m_sparsetools_matmat.cpp
@@ -17,6 +17,21 @@
 #include<stdlib.h>
 #include <omp.h>
 
+/*
+ * Count the number of non zeros element of the matrx C = AxB
+ *   where A is a sparse matrix in CSR format
+ *         B is a dense matrix
+ *         C is gonna to be a sparse matrix
+ *
+ * Inputs:
+ *   int nrow: number row A matrix
+ *   int ncol2: number column of matrix B
+ *   int *indptr: pinter index of matrix A
+ *
+ * Outputs:
+ *   int nnz: number of non zeros element of the matrix C
+ *
+ */
 extern "C" int count_nnz_spmat_denmat(int nrow, int ncol2, int *indptr)
 {
 
@@ -35,27 +50,141 @@ extern "C" int count_nnz_spmat_denmat(int nrow, int ncol2, int *indptr)
 
   return nnz;
 }
+/*
+ *  axpy operation
+ *
+ *    y = a*x + y
+ *
+ */
+void saxpy(int size, float a, float *x, float *y)
+{
+  int i = 0;
 
-//template <class I, class T>
-extern "C" void dcsr_matmat(int nrow, int ncol, int nnz, int *Ap, int *Aj, 
-    double *Ax, double *Xx, double *Yx)
+  for (i = 0; i < size; i++) {
+    y[i] += a*x[i];
+  }
+
+}
+
+void daxpy(int size, double a, double *x, double *y)
+{
+  int i = 0;
+
+  for (i = 0; i < size; i++) {
+    y[i] += a*x[i];
+  }
+
+}
+
+/*
+ * Performs the inner multiplication in matrix matrix multiplication
+ *
+ */
+void sinner_mult(int st, int fn, int *indices, float *data, int nrow_B, int ncol_B,
+                 float *B, float *y)
+{
+  int ind;
+
+  for (ind = st; ind < fn; ind++) {
+    daxpy(ncol_B, data[ind], &B[indices[ind]*ncol_B], y);
+  
+  }
+
+}
+
+void dinner_mult(int st, int fn, int *indices, double *data, int nrow_B, int ncol_B,
+                 double *B, double *y)
+{
+  int ind;
+
+  for (ind = st; ind < fn; ind++) {
+    daxpy(ncol_B, data[ind], &B[indices[ind]*ncol_B], y);
+  
+  }
+}
+
+/*
+ *  Perfrom a matrix matrix multiplication
+ *    C = AxB
+ *
+ *  where
+ *    A is a CSR sparse matrix
+ *    B is a dense matrix
+ *    C is a CSR sparse matrix
+ *
+ */
+extern "C" void scsr_spmat_denmat(int nrow_A, int ncol_A, int nnz_A, int *indptr_A,
+    int *indices_A, float *data_A, int nrow_B, int ncol_B, float *B,
+    int *indptr_C, int *indices_C, float *data_C)
 {
 
-  int i, jj;
-  double sum = 0.0;
+  int i, idx, st, fn, innz_st, innz_fn;
+  int col_index[ncol_B];
 
-  # pragma omp parallel \
-  shared (nrow, Yx, Ap, Ax, Xx, Aj) \
-  private (i, jj, sum)
-  {
-    int nthreads = omp_get_num_threads();
-    #pragma omp for schedule(dynamic, (nrow + 4*nthreads-1)/(4*nthreads))
-    for(i = 0; i < nrow; i++){
-      sum = Yx[i];
-      for(jj = Ap[i]; jj < Ap[i+1]; jj++){
-        sum += Ax[jj] * Xx[Aj[jj]];
-      }
-      Yx[i] = sum;
+  for (i = 0; i < ncol_B; i++) {
+    col_index[i] = i;
+  }
+
+  innz_st = 0;
+  for(i = 0; i < nrow_A; i++){
+  
+    st = indptr_A[i];
+    fn = indptr_A[i+1];
+
+    if (st == fn) {
+      indptr_C[i+1] = indptr_C[i];
     }
+
+    innz_fn = innz_st + ncol_B;
+
+    dinner_mult(st, fn, indices_A, data_A, nrow_B, ncol_B, B, &data_C[innz_st]);
+
+    // fill indices
+    for (idx = 0; idx < ncol_B; idx++) {
+      indices_C[innz_st+idx] = col_index[idx];
+    }
+
+    // get indptr
+    indptr_C[i+1] = indptr_C[i] + ncol_B;
+    innz_st += ncol_B;
+  
+  }
+}
+extern "C" void dcsr_spmat_denmat(int nrow_A, int ncol_A, int nnz_A, int *indptr_A,
+    int *indices_A, double *data_A, int nrow_B, int ncol_B, double *B,
+    int *indptr_C, int *indices_C, double *data_C)
+{
+
+  int i, idx, st, fn, innz_st, innz_fn;
+  int col_index[ncol_B];
+
+  // the indices for the row of C
+  for (i = 0; i < ncol_B; i++) {
+    col_index[i] = i;
+  }
+
+  innz_st = 0;
+  for(i = 0; i < nrow_A; i++){
+  
+    st = indptr_A[i];
+    fn = indptr_A[i+1];
+
+    if (st == fn) {
+      indptr_C[i+1] = indptr_C[i];
+    }
+
+    innz_fn = innz_st + ncol_B;
+
+    dinner_mult(st, fn, indices_A, data_A, nrow_B, ncol_B, B, &data_C[innz_st]);
+
+    // fill indices
+    for (idx = 0; idx < ncol_B; idx++) {
+      indices_C[innz_st+idx] = col_index[idx];
+    }
+
+    // get indptr
+    indptr_C[i+1] = indptr_C[i] + ncol_B;
+    innz_st += ncol_B;
+  
   }
 }

--- a/pyscf/lib/sparsetools/m_sparsetools_matmat.cpp
+++ b/pyscf/lib/sparsetools/m_sparsetools_matmat.cpp
@@ -86,7 +86,7 @@ void sinner_mult(int st, int fn, int *indices, float *data, int nrow_B, int ncol
   int ind;
 
   for (ind = st; ind < fn; ind++) {
-    daxpy(ncol_B, data[ind], &B[indices[ind]*ncol_B], y);
+    saxpy(ncol_B, data[ind], &B[indices[ind]*ncol_B], y);
   
   }
 
@@ -137,7 +137,7 @@ extern "C" void scsr_spmat_denmat(int nrow_A, int ncol_A, int nnz_A, int *indptr
 
     innz_fn = innz_st + ncol_B;
 
-    dinner_mult(st, fn, indices_A, data_A, nrow_B, ncol_B, B, &data_C[innz_st]);
+    sinner_mult(st, fn, indices_A, data_A, nrow_B, ncol_B, B, &data_C[innz_st]);
 
     // fill indices
     for (idx = 0; idx < ncol_B; idx++) {

--- a/pyscf/lib/sparsetools/m_sparsetools_matvec.cpp
+++ b/pyscf/lib/sparsetools/m_sparsetools_matvec.cpp
@@ -41,7 +41,7 @@
 !
 !   Complexity: Linear.  Specifically O(nnz(A) + n_row)
 */
-void scsr_matvec(int nrow, int ncol, int nnz, int *Ap, int *Aj, 
+extern "C" void scsr_matvec(int nrow, int ncol, int nnz, int *Ap, int *Aj, 
     float *Ax, float *Xx, float *Yx)
 {
 
@@ -64,8 +64,8 @@ void scsr_matvec(int nrow, int ncol, int nnz, int *Ap, int *Aj,
   }
 }
 
-
-void dcsr_matvec(int nrow, int ncol, int nnz, int *Ap, int *Aj, 
+//template <class I, class T>
+extern "C" void dcsr_matvec(int nrow, int ncol, int nnz, int *Ap, int *Aj, 
     double *Ax, double *Xx, double *Yx)
 {
 
@@ -111,7 +111,7 @@ void dcsr_matvec(int nrow, int ncol, int nnz, int *Ap, int *Aj,
  *   Complexity: Linear.  Specifically O(nnz(A) + n_col)
  *
  */
-void scsc_matvec(int n_row, int n_col, int nnz,
+extern "C" void scsc_matvec(int n_row, int n_col, int nnz,
             int *Ap, int *Ai, float *Ax, float *Xx, float *Yx)
 {
     int col_start, col_end, j, ii, i;
@@ -127,7 +127,7 @@ void scsc_matvec(int n_row, int n_col, int nnz,
     }
 }
 
-void dcsc_matvec(int n_row, int n_col, int nnz,
+extern "C" void dcsc_matvec(int n_row, int n_col, int nnz,
             int *Ap, int *Ai, double *Ax, double *Xx, double *Yx)
 {
     int col_start, col_end, j, ii, i;
@@ -165,7 +165,7 @@ void dcsc_matvec(int n_row, int n_col, int nnz,
  *   Output array Yx must be preallocated
  *
 */
-void scsc_matvecs(int n_row, int n_col, int n_vecs, 
+extern "C" void scsc_matvecs(int n_row, int n_col, int n_vecs, 
       int *Ap, int *Ai, float *Ax, float *Xx, float *Yx)
 {
   int i, j, ii;
@@ -188,7 +188,7 @@ void scsc_matvecs(int n_row, int n_col, int n_vecs,
     */
 }
 
-void dcsc_matvecs(int n_row, int n_col, int n_vecs, 
+extern "C" void dcsc_matvecs(int n_row, int n_col, int n_vecs, 
       int *Ap, int *Ai, double *Ax, double *Xx, double *Yx)
 {
   int i, j, ii;

--- a/pyscf/nao/m_kmat_den.py
+++ b/pyscf/nao/m_kmat_den.py
@@ -247,7 +247,9 @@ def sm0_sum(pb, mf, hk, dm):
         bp_b2hv = csr_matvec(mf.v_dab_trans, nu2v).reshape((n, n))
         tt[5] = timer();
 
-        ab2vdhv = spmat_denmat(a_bp2vd, bp_b2hv)
+        # This retuned a seg fault  for large system ??
+        # ab2vdhv = spmat_denmat(a_bp2vd, bp_b2hv)
+        ab2vdhv = a_bp2vd.dot(bp_b2hv)
         tt[6] = timer()
 
         kmat += ab2vdhv
@@ -256,5 +258,5 @@ def sm0_sum(pb, mf, hk, dm):
         ttt += tt[1:8]-tt[0:7]
         
     print(__name__, ttt)
-
-    return np.require(np.asarray(kmat), dtype=kmat.dtype,  requirements=['A', 'O', 'W', 'C'])
+    return kmat
+    #return np.require(np.asarray(kmat), dtype=kmat.dtype,  requirements=['A', 'O', 'W', 'C'])

--- a/pyscf/nao/m_kmat_den.py
+++ b/pyscf/nao/m_kmat_den.py
@@ -14,7 +14,9 @@
 from __future__ import print_function, division
 import numpy as np
 import scipy.linalg.blas as blas
-from pyscf.nao.m_sparsetools import csr_matvec, csc_matvec
+import scipy.sparse as sparse
+from timeit import default_timer as timer
+from pyscf.nao.m_sparsetools import csr_matvec, csc_matvec, spmat_denmat
 
 def kmat_den(mf, dm=None, algo=None, **kw):
     """
@@ -117,7 +119,6 @@ def kmat_den(mf, dm=None, algo=None, **kw):
             raise RuntimeError('to impl dm.shape')
 
     elif algol == 'sm0_prd':
-        import scipy.sparse as sparse
         if gen_spy_png: 
             import matplotlib.pyplot as plt
             plt.ioff()
@@ -171,83 +172,33 @@ def kmat_den(mf, dm=None, algo=None, **kw):
         vertex V^ab_mu. The algorithm was not realized before and it seems
         to be superior to the algorithm sm0_prd (see above).
         """
-        import scipy.sparse as sparse
-        from timeit import default_timer as timer
         #t1 = timer()
 
-        if hasattr(mf, 'dab2v'):
-            dab2v = mf.dab2v
-        else:
-            mf.dab2v = dab2v =  pb.get_dp_vertex_doubly_sparse(axis=0)
-
-        da2cc = mf.cc_da_csr
-        kmat  = np.zeros_like(dm)
-        (nnd,nnp),n = da2cc.shape,dm.shape[-1]
 
         if len(dm.shape) == 3:
             # if spin index is present
 
             for s in range(mf.nspin):
-                for mu, a_ap2v in enumerate(dab2v):
-                    cc = da2cc[mu].toarray().reshape(nnp)
-                    q2v = np.dot( cc, hk )
-                    nu2v = da2cc * q2v
-                    a_bp2vd = sparse.csr_matrix(a_ap2v * dm[s])
-                    bp_b2hv = sparse.csr_matrix((nu2v * mf.v_dab_csr).reshape((n,n)))
-                    ab2vdhv = a_bp2vd * bp_b2hv
-                    kmat[s][ab2vdhv.nonzero()] += ab2vdhv.data
+                #kmat[s][ab2vdhv.nonzero()] += ab2vdhv.data
+                kmat[s] = sm0_sum(pb, mf, hk, dm[s])
+#                for mu, a_ap2v in enumerate(dab2v):
+#                    cc = da2cc[mu].toarray().reshape(nnp)
+#                    q2v = np.dot( cc, hk )
+#                    nu2v = da2cc * q2v
+#                    a_bp2vd = sparse.csr_matrix(a_ap2v * dm[s])
+#                    bp_b2hv = sparse.csr_matrix((nu2v * mf.v_dab_csr).reshape((n,n)))
+#                    ab2vdhv = a_bp2vd * bp_b2hv
+#                    kmat[s][ab2vdhv.nonzero()] += ab2vdhv.data
             
         elif len(dm.shape) == 2:
             # if spin index is absent
             # [   14.59955484   314.09553769  1113.57001527   140.44369524   687.34180544   89.05969492    28.3846701 ]
             # C60: [ 15.85272067 288.39123102 153.34696097 578.67634735 128.22075884
             # 583.69870308 22.44895533]
+
+            kmat = sm0_sum(pb, mf, hk, dm)
           
-            tt = np.zeros(8)
-            ttt = np.zeros(7)
-
-            for mu, a_ap2v in enumerate(dab2v):
-                
-                tt[0] = timer();
-                # 1D; dense, could be sparse ... 
-                cc = da2cc[mu].toarray().reshape(nnp)
-                tt[1] = timer(); 
-
-                # this could be done directly
-                # Slower term for large systems
-                # blas dgemv is much slower than np.dot
-                # That is odd!!
-                # q2v = blas.dgemv( 1.0, hk, cc, trans=1 )
-                q2v = cc.dot(hk)
-                tt[2] = timer();
-
-                # slower term ..
-                #nu2v = da2cc.dot(q2v)
-                nu2v = csr_matvec(da2cc, q2v)
-                tt[3] = timer();
-
-                # a_ap2v: sparse
-                a_bp2vd = sparse.coo_matrix(a_ap2v.dot(dm),
-                                            dtype=a_ap2v.dtype).tocsr()
-                tt[4] = timer();
-                # bp_b2hv = sparse.csr_matrix((nu2v * dab2v_csr).reshape((n,n)))
-                
-                # slower term ..
-                #bp_b2hv = dab2v_csr.T.dot(nu2v).reshape((n,n))
-                # bp_b2hv = csc_matvec(dab2v_csr.T, nu2v).reshape((n,n))
-                bp_b2hv = csr_matvec(mf.v_dab_trans, nu2v).reshape((n, n))
-                tt[5] = timer();
-                
-                ab2vdhv = a_bp2vd.dot(bp_b2hv)
-                tt[6] = timer()
-                # kmat[ab2vdhv.nonzero()] += ab2vdhv.data
-
-                kmat += ab2vdhv
-                tt[7] = timer()
-                ttt += tt[1:8]-tt[0:7]
-                
-            print(__name__, ttt)
-              
+             
         else:
             print(dm.shape)
             raise RuntimeError('?dm.shape?')
@@ -258,3 +209,64 @@ def kmat_den(mf, dm=None, algo=None, **kw):
         raise RuntimeError('unknown algorithm')
 
     return kmat
+
+def sm0_sum(pb, mf, hk, dm):
+
+    if hasattr(mf, 'dab2v'):
+        dab2v = mf.dab2v
+    else:
+        mf.dab2v = dab2v =  pb.get_dp_vertex_doubly_sparse(axis=0)
+
+    da2cc = mf.cc_da_csr
+    kmat  = np.zeros_like(dm)
+    (nnd, nnp) = da2cc.shape
+    n = dm.shape[-1]
+
+    tt = np.zeros(8)
+    ttt = np.zeros(7)
+
+    for mu, a_ap2v in enumerate(dab2v):
+        
+        tt[0] = timer();
+
+        # 1D; dense, could be sparse ... 
+        cc = da2cc[mu].toarray().reshape(nnp)
+        tt[1] = timer(); 
+
+        # this could be done directly
+        # Slower term for large systems
+        # blas dgemv is much slower than np.dot
+        # That is odd!!
+        # q2v = blas.dgemv( 1.0, hk, cc, trans=1 )
+        q2v = cc.dot(hk)
+        tt[2] = timer();
+
+        # slower term ..
+        #nu2v = da2cc.dot(q2v)
+        nu2v = csr_matvec(da2cc, q2v)
+        tt[3] = timer();
+
+        # a_ap2v: sparse
+        a_bp2vd = spmat_denmat(a_ap2v, dm)
+        #a_bp2vd = sparse.coo_matrix(a_ap2v.dot(dm),
+        #                            dtype=a_ap2v.dtype).tocsr()
+        tt[4] = timer();
+        # bp_b2hv = sparse.csr_matrix((nu2v * dab2v_csr).reshape((n,n)))
+        
+        # slower term ..
+        #bp_b2hv = dab2v_csr.T.dot(nu2v).reshape((n,n))
+        # bp_b2hv = csc_matvec(dab2v_csr.T, nu2v).reshape((n,n))
+        bp_b2hv = csr_matvec(mf.v_dab_trans, nu2v).reshape((n, n))
+        tt[5] = timer();
+        
+        ab2vdhv = a_bp2vd.dot(bp_b2hv)
+        tt[6] = timer()
+        # kmat[ab2vdhv.nonzero()] += ab2vdhv.data
+
+        kmat += ab2vdhv
+        tt[7] = timer()
+        ttt += tt[1:8]-tt[0:7]
+        
+    print(__name__, ttt)
+
+    return kmat     

--- a/pyscf/nao/m_kmat_den.py
+++ b/pyscf/nao/m_kmat_den.py
@@ -185,9 +185,6 @@ def kmat_den(mf, dm=None, algo=None, **kw):
             
         elif len(dm.shape) == 2:
             # if spin index is absent
-            # [   14.59955484   314.09553769  1113.57001527   140.44369524   687.34180544   89.05969492    28.3846701 ]
-            # C60: [ 15.85272067 288.39123102 153.34696097 578.67634735 128.22075884
-            # 583.69870308 22.44895533]
 
             kmat = sm0_sum(pb, mf, hk, dm)
         else:
@@ -207,6 +204,12 @@ def sm0_sum(pb, mf, hk, dm):
     vertex V^ab_mu. The algorithm was not realized before and it seems
     to be superior to the algorithm sm0_prd (see above).
     """
+
+    # C60
+    # [ 15.85272067 288.39123102 153.34696097 578.67634735 128.22075884 583.69870308 22.44895533]
+    # 2 alpha-NPD
+    # [  19.57798671 1186.84709886  279.20988026  136.44827988 2879.76712975 291.75671738 1538.04936546   99.47608311]
+    # [  21.2088159  1186.7482362   279.53348225  59.28001652  388.78893778 3198.20760651 76.97475073 ]
     if hasattr(mf, 'dab2v'):
         dab2v = mf.dab2v
     else:
@@ -229,10 +232,6 @@ def sm0_sum(pb, mf, hk, dm):
         tt[1] = timer(); 
 
         # this could be done directly
-        # Slower term for large systems
-        # blas dgemv is much slower than np.dot
-        # That is odd!!
-        # q2v = blas.dgemv( 1.0, hk, cc, trans=1 )
         q2v = cc.dot(hk)
         tt[2] = timer();
 
@@ -243,25 +242,19 @@ def sm0_sum(pb, mf, hk, dm):
 
         # a_ap2v: sparse
         a_bp2vd = spmat_denmat(a_ap2v, dm)
-        #a_bp2vd = sparse.coo_matrix(a_ap2v.dot(dm),
-        #                            dtype=a_ap2v.dtype).tocsr()
         tt[4] = timer();
-        # bp_b2hv = sparse.csr_matrix((nu2v * dab2v_csr).reshape((n,n)))
         
-        # slower term ..
-        #bp_b2hv = dab2v_csr.T.dot(nu2v).reshape((n,n))
-        # bp_b2hv = csc_matvec(dab2v_csr.T, nu2v).reshape((n,n))
         bp_b2hv = csr_matvec(mf.v_dab_trans, nu2v).reshape((n, n))
         tt[5] = timer();
-        
-        ab2vdhv = a_bp2vd.dot(bp_b2hv)
+
+        ab2vdhv = spmat_denmat(a_bp2vd, bp_b2hv)
         tt[6] = timer()
-        # kmat[ab2vdhv.nonzero()] += ab2vdhv.data
 
         kmat += ab2vdhv
+
         tt[7] = timer()
         ttt += tt[1:8]-tt[0:7]
         
     print(__name__, ttt)
 
-    return kmat     
+    return np.require(np.asarray(kmat), dtype=kmat.dtype,  requirements=['A', 'O', 'W', 'C'])

--- a/pyscf/nao/m_kmat_den.py
+++ b/pyscf/nao/m_kmat_den.py
@@ -172,23 +172,16 @@ def kmat_den(mf, dm=None, algo=None, **kw):
         vertex V^ab_mu. The algorithm was not realized before and it seems
         to be superior to the algorithm sm0_prd (see above).
         """
-        #t1 = timer()
-
 
         if len(dm.shape) == 3:
             # if spin index is present
+        
+            kmat  = np.zeros_like(dm)
+            print(kmat.shape)
 
-            for s in range(mf.nspin):
+            for spin in range(mf.nspin):
                 #kmat[s][ab2vdhv.nonzero()] += ab2vdhv.data
-                kmat[s] = sm0_sum(pb, mf, hk, dm[s])
-#                for mu, a_ap2v in enumerate(dab2v):
-#                    cc = da2cc[mu].toarray().reshape(nnp)
-#                    q2v = np.dot( cc, hk )
-#                    nu2v = da2cc * q2v
-#                    a_bp2vd = sparse.csr_matrix(a_ap2v * dm[s])
-#                    bp_b2hv = sparse.csr_matrix((nu2v * mf.v_dab_csr).reshape((n,n)))
-#                    ab2vdhv = a_bp2vd * bp_b2hv
-#                    kmat[s][ab2vdhv.nonzero()] += ab2vdhv.data
+                kmat[spin, :, :] = sm0_sum(pb, mf, hk, dm[spin])
             
         elif len(dm.shape) == 2:
             # if spin index is absent
@@ -197,8 +190,6 @@ def kmat_den(mf, dm=None, algo=None, **kw):
             # 583.69870308 22.44895533]
 
             kmat = sm0_sum(pb, mf, hk, dm)
-          
-             
         else:
             print(dm.shape)
             raise RuntimeError('?dm.shape?')
@@ -211,7 +202,11 @@ def kmat_den(mf, dm=None, algo=None, **kw):
     return kmat
 
 def sm0_sum(pb, mf, hk, dm):
-
+    """ 
+    This algorithm is using two sparse representations of the product 
+    vertex V^ab_mu. The algorithm was not realized before and it seems
+    to be superior to the algorithm sm0_prd (see above).
+    """
     if hasattr(mf, 'dab2v'):
         dab2v = mf.dab2v
     else:

--- a/pyscf/nao/m_sparsetools.py
+++ b/pyscf/nao/m_sparsetools.py
@@ -19,14 +19,14 @@ from ctypes import POINTER, c_double, c_int, c_int64, c_float, c_int
 
 libsparsetools = misc.load_library("libsparsetools")
 
-def count_nnz_spmat_denmat(csr, B):
+def count_nnz_spmat_denmat(csr, ncolB):
 
     nrow, ncol = csr.shape
     if not sparse.isspmatrix_csr(csr):
         raise Exception("Matrix must be in csr format")
 
     nnz = libsparsetools.count_nnz_spmat_denmat(
-            c_int(nrow), c_int(B.shape[1]),
+            c_int(nrow), c_int(ncolB),
             csr.indptr.ctypes.data_as(POINTER(c_int)))
 
     return nnz
@@ -37,7 +37,7 @@ def spmat_denmat(csr, B):
         raise Exception("Matrix must be in csr format")
 
     nrow, ncol = csr.shape
-    nnz = count_nnz_spmat_denmat(csr, B)
+    nnz = count_nnz_spmat_denmat(csr, B.shape[1])
     
     indptr_new = np.zeros((csr.shape[0]+1), dtype=np.int32)
     indices_new = np.zeros((nnz), dtype=np.int32)
@@ -70,7 +70,8 @@ def spmat_denmat(csr, B):
     else:
         raise ValueError("Not implemented")
 
-    return sparse.csr_matrix((data_new, indices_new, indptr_new), shape=(nrow, B.shape[1]))
+    ret = sparse.csr_matrix((data_new, indices_new, indptr_new), shape=(nrow, B.shape[1]))
+    return ret
 
 """
     Wrapper to sparse matrix operations from scipy implemented with openmp

--- a/pyscf/nao/m_sparsetools.py
+++ b/pyscf/nao/m_sparsetools.py
@@ -44,7 +44,16 @@ def spmat_denmat(csr, B):
     data_new = np.zeros((nnz), dtype=csr.data.dtype)
 
     if csr.dtype == np.float32:
-        raise ValueError("not yet implemented")
+        libsparsetools.scsr_spmat_denmat(
+                c_int(nrow), c_int(ncol), c_int(csr.nnz), 
+                csr.indptr.ctypes.data_as(POINTER(c_int)),
+                csr.indices.ctypes.data_as(POINTER(c_int)), 
+                csr.data.ctypes.data_as(POINTER(c_float)),
+                c_int(B.shape[0]), c_int(B.shape[1]),
+                B.ctypes.data_as(POINTER(c_float)),
+                indptr_new.ctypes.data_as(POINTER(c_int)),
+                indices_new.ctypes.data_as(POINTER(c_int)), 
+                data_new.ctypes.data_as(POINTER(c_float)))
 
     elif csr.dtype == np.float64:
         libsparsetools.dcsr_spmat_denmat(

--- a/pyscf/nao/m_sparsetools.py
+++ b/pyscf/nao/m_sparsetools.py
@@ -19,6 +19,18 @@ from ctypes import POINTER, c_double, c_int, c_int64, c_float, c_int
 
 libsparsetools = misc.load_library("libsparsetools")
 
+def count_nnz_spmat_denmat(csr, B):
+
+    nrow, ncol = csr.shape
+    if not sparse.isspmatrix_csr(csr):
+        raise Exception("Matrix must be in csr format")
+
+    nnz = libsparsetools.count_nnz_spmat_denmat(
+            c_int(nrow), c_int(B.shape[1]),
+            csr.indptr.ctypes.data_as(POINTER(c_int)))
+
+    return nnz
+
 """
     Wrapper to sparse matrix operations from scipy implemented with openmp
 """


### PR DESCRIPTION
in `sm0_sum` algo in `kmat_den`, the conversion to sparse matrix in the following line becomes prohibitive for large systems. 

    a_bp2vd = sparse.coo_matrix(a_ap2v.dot(dm), dtype=a_ap2v.dtype).tocsr()

The solution is to use a sparse matrix dense matrix multiplication with return directly a sparse matrix in CSR format.