### PR TITLE
managed to use dp_coo scipy sparse in gw_iter

### DIFF
--- a/pyscf/nao/gw_iter.py
+++ b/pyscf/nao/gw_iter.py
@@ -42,7 +42,7 @@ class gw_iter(gw):
 
     self.gw_iter_tol = kw['gw_iter_tol'] if 'gw_iter_tol' in kw else 1e-4
     self.maxiter = kw['maxiter'] if 'maxiter' in kw else 1000
-    self.gw_xvx_algo = kw['gw_xvx_algo'] if 'gw_xvx_algo' in kw else "blas"
+    self.gw_xvx_algo = kw['gw_xvx_algo'] if 'gw_xvx_algo' in kw else "ac_blas"
 
     self.limited_nbnd = kw['limited_nbnd'] if 'limited_nbnd' in kw else False
     if (self.limited_nbnd and min (self.vst) < 50 ):
@@ -54,8 +54,8 @@ class gw_iter(gw):
     self.ncall_chi0_mv_ite = 0
     self.ncall_chi0_mv_total = 0
 
-    # Store the ac product basis if necessary (sparse)
-    self.vpab = None
+    # Store the ac product basis if necessary (ac_sparse)
+    self.v_pab = None
 
   def si_c2(self,ww):
     """
@@ -344,11 +344,11 @@ class gw_iter(gw):
     ww = 1j*self.ww_ia
     rf0 = self.rf0(ww)
     #V_{\mu}^{ab}
-    if self.vpab is None:
+    if self.v_pab is None:
         v_pab = self.pb.get_ac_vertex_array(matformat="dense",
                                             dtype=self.dtype)
     else:
-        v_pab = self.vpab
+        v_pab = self.v_pab
 
     for s in range(self.nspin):
       v_eff = np.zeros((len(self.nn[s]), self.nprod), dtype=self.dtype)

--- a/pyscf/nao/gw_iter.py
+++ b/pyscf/nao/gw_iter.py
@@ -599,14 +599,15 @@ class gw_iter(gw):
             for pole, z_real in zip(lsos, zww):
                 self.comega_current = z_real
                 #xvx = xv.dot(x[pole[1]])
-                a = np.dot(self.kernel_sq, xvx[spin][n, pole[1], :])
+                print(spin, n, pole[1], xvx[spin].shape)
+                a = self.kernel_sq.dot(xvx[spin][nl, pole[1], :])
                 b = self.chi0_mv(a, self.comega_current)
-                a = np.dot(self.kernel_sq, b)
+                a = self.kernel_sq.dot(b)
                 si_xvx, exitCode = lgmres(k_c_opt, a, atol=self.gw_iter_tol,
                                           maxiter=self.maxiter)
                 if exitCode != 0:
                     print("LGMRES has not achieved convergence: exitCode = {}".format(exitCode))
-                contr = xvx[spin][n, pole[1], :].dot(si_xvx)
+                contr = xvx[spin][nl, pole[1], :].dot(si_xvx)
                 sn2res[spin][nl] += pole[2]*contr.real
 
     return sn2res

--- a/pyscf/nao/gw_iter.py
+++ b/pyscf/nao/gw_iter.py
@@ -599,7 +599,6 @@ class gw_iter(gw):
             for pole, z_real in zip(lsos, zww):
                 self.comega_current = z_real
                 #xvx = xv.dot(x[pole[1]])
-                print(spin, n, pole[1], xvx[spin].shape)
                 a = self.kernel_sq.dot(xvx[spin][nl, pole[1], :])
                 b = self.chi0_mv(a, self.comega_current)
                 a = self.kernel_sq.dot(b)

--- a/pyscf/nao/m_gw_xvx.py
+++ b/pyscf/nao/m_gw_xvx.py
@@ -1,0 +1,41 @@
+from __future__ import division
+import numpy as np
+
+def gw_xvx_dpcoo(self):
+
+    xvx = []
+    size = self.cc_da.shape[0]
+    nfdp = self.pb.dpc2s[-1]
+
+    for spin in range(self.nspin):
+
+        vxdp = dpcoo_step1(self, size, nfdp, spin)
+        vxdp = dpcoo_step2(vxdp, size, self.norbs)
+        vxdp = dpcoo_step3(self, vxdp, size, spin)
+        xvx.append(dpcoo_step4(self.cc_da, vxdp).todense())
+
+    return xvx
+
+def dpcoo_step1(self, size, nfdp, spin):
+    import sparse
+
+    xmb = sparse.COO.from_numpy(self.mo_coeff[0, spin, :, :, 0]).T
+    v_pd = sparse.COO.from_scipy_sparse(self.v_dab.reshape(nfdp*self.norbs, self.norbs))
+
+    return sparse.COO.dot(v_pd, xmb)
+
+def dpcoo_step2(vxdp, size, norbs):
+
+    return vxdp.reshape((size, norbs, \
+            norbs)).transpose(axes=(1, 0, 2)).reshape((norbs, size*norbs))
+
+def dpcoo_step3(self, vxdp, size, spin):
+    import sparse
+
+    xna = sparse.COO.from_numpy(self.mo_coeff[0, spin, self.nn[spin], :, 0])
+    xxv2 = xna.dot(vxdp).reshape((len(self.nn[spin]), size, self.norbs))
+    return xxv2.transpose(axes=(0, 2, 1))
+
+def dpcoo_step4(cc_da, vxdp):
+    import sparse
+    return vxdp.dot(sparse.COO.from_scipy_sparse(cc_da))

--- a/pyscf/nao/m_gw_xvx.py
+++ b/pyscf/nao/m_gw_xvx.py
@@ -1,41 +1,104 @@
 from __future__ import division
 import numpy as np
+from scipy.sparse import coo_matrix, csr_matrix
+import numba as nb
+from memory_profiler import profile
 
+@profile
 def gw_xvx_dpcoo(self):
 
     xvx = []
     size = self.cc_da.shape[0]
     nfdp = self.pb.dpc2s[-1]
+    v_pd = self.v_dab.reshape(self.v_dab_csr.shape[0]*self.norbs, self.norbs).tocsr()
 
     for spin in range(self.nspin):
 
-        vxdp = dpcoo_step1(self, size, nfdp, spin)
-        vxdp = dpcoo_step2(vxdp, size, self.norbs)
-        vxdp = dpcoo_step3(self, vxdp, size, spin)
-        xvx.append(dpcoo_step4(self.cc_da, vxdp).todense())
+        xvx2 = csrmat_denmat_custom2(v_pd.indptr, v_pd.indices, v_pd.data,
+                                     self.mo_coeff[0, spin, :, :, 0].T,
+                                     self.mo_coeff[0, spin, self.nn[spin], :, 0],
+                                     nfdp, self.norbs, len(self.nn[spin]))
+        xvx2 = xvx2.reshape(len(self.nn[spin]), size, self.norbs)
+        xvx2 = np.swapaxes(xvx2, 1, 2)
+
+        xvx2_fin = np.zeros((xvx2.shape[0], xvx2.shape[1], self.cc_da.shape[1]),
+                             dtype=xvx2.dtype)
+        # Somehow dense.dot(sparse) uses a crazy amount of memory ...
+        # xvx2 = xvx2.dot(self.cc_da)
+        for i in range(xvx2_fin.shape[0]):
+            xvx2_fin[i, :, :] = self.cc_da_trans.dot(xvx2[i, :, :].T).T
+
+        xvx.append(xvx2_fin)
 
     return xvx
 
+@nb.jit(nopython=True)
+def csrmat_denmat_custom2(indptr, indices, data, B, X, N1, N2, N3):
+    """
+    Perform in one shot the following operations (avoiding the use of temporary arrays):
+
+    vxdp  = v_pd1.dot(xmb.T)
+    vxdp  = vxdp.reshape(size,self.norbs, self.norbs)
+    xvx2 = np.swapaxes(vxdp,0,1)
+    xvx2 = xvx2.reshape(self.norbs,-1)
+    xvx2 = xna.dot(xvx2)
+
+    The array vxdp is pretty larger: (size*norbs, norbs) and pretty dense (0.1%)
+    It is better to avoid its allocation for large systems.
+    """
+
+    D = np.zeros((N3, N1*N2), dtype=B.dtype)
+
+    for jp in range(N2):
+        Ctmp = np.zeros((N1*N2), dtype=B.dtype)
+        for ip in range(N1):
+            i = ip*N2 + jp
+            for kp in range(N2):
+                ipp = ip*N2 + kp
+
+                for ind in range(indptr[i], indptr[i+1]):
+                    k = indices[ind]
+                    Ctmp[ipp] += data[ind]*B[k, kp]
+
+        for ix in range(N3):
+            for jx in range(N1*N2):
+                D[ix, jx] += X[ix, jp]*Ctmp[jx]
+
+    return D
+
+@profile
 def dpcoo_step1(self, size, nfdp, spin):
     import sparse
 
-    xmb = sparse.COO.from_numpy(self.mo_coeff[0, spin, :, :, 0]).T
-    v_pd = sparse.COO.from_scipy_sparse(self.v_dab.reshape(nfdp*self.norbs, self.norbs))
+    xmb = csr_matrix(self.mo_coeff[0, spin, :, :, 0]).T
+    print("xmb: ", xmb.nnz, xmb.shape)
+    v_pd = self.v_dab_csr.reshape(nfdp*self.norbs, self.norbs)
+    vxdp = v_pd.dot(xmb).tocoo()
+    print("nnz: ", vxdp.nnz, "shape: ", vxdp.shape)
+    return sparse.COO.from_scipy_sparse(vxdp)
 
-    return sparse.COO.dot(v_pd, xmb)
-
+@profile
 def dpcoo_step2(vxdp, size, norbs):
 
-    return vxdp.reshape((size, norbs, \
-            norbs)).transpose(axes=(1, 0, 2)).reshape((norbs, size*norbs))
+    xxv2 = vxdp.reshape((size, norbs, norbs))
+    print("nnz: ", xxv2.nnz, "shape: ", xxv2.shape)
+    xxv2 = xxv2.transpose(axes=(1, 0, 2))
+    print("nnz: ", xxv2.nnz, "shape: ", xxv2.shape)
+    xxv2 = xxv2.reshape((norbs, size*norbs))
+    print("nnz: ", xxv2.nnz, "shape: ", xxv2.shape)
+    return xxv2
 
+@profile
 def dpcoo_step3(self, vxdp, size, spin):
     import sparse
 
     xna = sparse.COO.from_numpy(self.mo_coeff[0, spin, self.nn[spin], :, 0])
+    print("xna:", xna.shape, xna.nnz)
     xxv2 = xna.dot(vxdp).reshape((len(self.nn[spin]), size, self.norbs))
+    print("xxv2:", xxv2.shape, xxv2.nnz)
     return xxv2.transpose(axes=(0, 2, 1))
 
+@profile
 def dpcoo_step4(cc_da, vxdp):
     import sparse
     return vxdp.dot(sparse.COO.from_scipy_sparse(cc_da))

--- a/pyscf/nao/m_gw_xvx.py
+++ b/pyscf/nao/m_gw_xvx.py
@@ -61,7 +61,7 @@ def gw_xvx_ac(self):
 
         # Third step
         xvx1 = xna.dot(xvx1)
-        xvx1 = xvx1.reshape(len(self.nn[s]),self.nprod,self.norbs)
+        xvx1 = xvx1.reshape(len(self.nn[spin]), self.nprod, self.norbs)
         xvx1 = np.swapaxes(xvx1, 1, 2)
 
         xvx.append(xvx1)
@@ -104,16 +104,18 @@ def gw_xvx_ac_sparse(self):
     from pyscf.nao.m_rf0_den import calc_XVX
 
     xvx = []
-    t1 = timer()
-    v_pab = self.pb.get_ac_vertex_array(matformat="sparse", dtype=self.dtype)
-    v = self.vpab.transpose(axes=(1, 0, 2))
-    t2 = timer()
 
-    if self.verbosity>3:
-        print("Get AC vertex timing: ", t2-t1)
-        print("Vpab.shape: ", v.shape)
-        print("Vpab.nnz: ", v.nnz)
+    if self.v_pab is None:
+        t1 = timer()
+        self.v_pab = self.pb.get_ac_vertex_array(matformat="sparse", dtype=self.dtype)
+        t2 = timer()
 
+        if self.verbosity>3:
+            print("Get AC vertex timing: ", t2-t1)
+            print("Vpab.shape: ", self.v_pab.shape)
+            print("Vpab.nnz: ", self.v_pab.nnz)
+
+    v = self.v_pab.transpose(axes=(1, 0, 2))
     for spin in range(self.nspin):
 
         vx = v.dot(self.mo_coeff[0, spin, self.nn[spin], :, 0].T)

--- a/pyscf/nao/m_gw_xvx_dp_sparse.py
+++ b/pyscf/nao/m_gw_xvx_dp_sparse.py
@@ -1,0 +1,91 @@
+from __future__ import division
+import numpy as np
+from scipy.sparse import coo_matrix, csr_matrix
+import numba as nb
+
+def gw_xvx_sparse_dp(self):
+    """
+    Calculate the basis product using sparse dominant product basis
+    """
+
+    xvx = []
+    size = self.cc_da.shape[0]
+    nfdp = self.pb.dpc2s[-1]
+    v_pd = self.v_dab.reshape(self.v_dab_csr.shape[0]*self.norbs, self.norbs).tocsr()
+
+    for spin in range(self.nspin):
+
+        xvx2 = csrmat_denmat_custom2(v_pd.indptr, v_pd.indices, v_pd.data,
+                                     self.mo_coeff[0, spin, :, :, 0].T,
+                                     self.mo_coeff[0, spin, self.nn[spin], :, 0],
+                                     nfdp, self.norbs, len(self.nn[spin]))
+        xvx2 = xvx2.reshape(len(self.nn[spin]), size, self.norbs)
+        xvx2 = np.swapaxes(xvx2, 1, 2)
+
+        xvx2_fin = np.zeros((xvx2.shape[0], xvx2.shape[1], self.cc_da.shape[1]),
+                             dtype=xvx2.dtype)
+
+        # xvx2 = xvx2.dot(self.cc_da)
+        # Somehow dense.dot(sparse) uses a crazy amount of memory ...
+        # better to do sparse.T.dot(dense.T).T
+        for i in range(xvx2_fin.shape[0]):
+            xvx2_fin[i, :, :] = self.cc_da_trans.dot(xvx2[i, :, :].T).T
+
+        xvx.append(xvx2_fin)
+
+    return xvx
+
+@nb.jit(nopython=True)
+def csrmat_denmat_custom2(indptr, indices, data, B, X, N1, N2, N3):
+    """
+    Perform in one shot the following operations (avoiding the use of temporary arrays):
+
+    vxdp  = v_pd1.dot(xmb.T)
+    vxdp  = vxdp.reshape(size,self.norbs, self.norbs)
+    vxdp = np.swapaxes(vxdp,0,1)
+    vxdp = vxdp.reshape(self.norbs,-1)
+    xvx2 = xna.dot(xvx2)
+
+    The array vxdp is pretty large: (nfdp*norbs, norbs) and quite dense (0.1%)
+    It is better to avoid its use for large systems, even in sparse format.
+
+    Inputs:
+        indptr: pointer index of v_dab in csr format
+        indices: column indices of v_dab in csr format
+        data: non zeros element of v_dab
+        B: transpose of self.mo_coeff[0, spin, :, :, 0]
+        X: self.mo_coeff[0, spin, self.nn[spin], :, 0]
+        N1: nfdp
+        N2: norbs
+        N3: len(nn[spin])
+
+    Outputs:
+        D: xxv2 store in dense format
+    """
+
+    D = np.zeros((N3, N1*N2), dtype=B.dtype)
+
+    # performs at the same time:
+    # the matrix matrix product vxdp = v_pd1.dot(xmb.T), where v_pd1 is in CSR format
+    # the reshape operations and sweepaxes on vxdp
+    # finally the matrix matrix product xvx2 = xna.dot(xvx2)
+    for jp in range(N2):
+
+        # vxdp = v_pd1.dot(xmb.T)
+        # store only one row of vxdp at a time
+        Ctmp = np.zeros((N1*N2), dtype=B.dtype)
+        for ip in range(N1):
+            i = ip*N2 + jp
+            for kp in range(N2):
+                ipp = ip*N2 + kp
+
+                for ind in range(indptr[i], indptr[i+1]):
+                    k = indices[ind]
+                    Ctmp[ipp] += data[ind]*B[k, kp]
+
+        # xvx2 = xna.dot(xvx2)
+        for ix in range(N3):
+            for jx in range(N1*N2):
+                D[ix, jx] += X[ix, jp]*Ctmp[jx]
+
+    return D

--- a/pyscf/nao/m_sparsetools.py
+++ b/pyscf/nao/m_sparsetools.py
@@ -32,6 +32,10 @@ def count_nnz_spmat_denmat(csr, ncolB):
     return nnz
 
 def spmat_denmat(csr, B):
+    """
+    sparse matrix dense matrix multiplication directly giving a sparse matrix
+    in CSR format.
+    """
 
     if not sparse.isspmatrix_csr(csr):
         raise Exception("Matrix must be in csr format")


### PR DESCRIPTION
use sparse COO scipy format for the dominant product in `gw_xvx`. However, `gw_corr_res_iter` still uses the atom center vertex.