### PR TITLE
divides convergence in QP into int and res parts

### DIFF
--- a/pyscf/nao/gw.py
+++ b/pyscf/nao/gw.py
@@ -252,18 +252,11 @@ class gw(scf):
     snmw2sf = []
     for s in range(self.nspin):
       nmw2sf = zeros((len(self.nn[s]), self.norbs, self.nff_ia), dtype=self.dtype)
-      #nmw2sf = zeros((len(self.nn), self.norbs, self.nff_ia), dtype=self.dtype)
-
-      # n runs from s...f or states will be corrected:
-      # self.nn = [range(self.start_st[s], self.finish_st[s])
       xna = self.mo_coeff[0,s,self.nn[s],:,0]
-      #xna = self.mo_coeff[0,s,self.nn,:,0]
-
-      # m runs from 0...norbs
       xmb = self.mo_coeff[0,s,:,:,0]
-
-      # This calculates nmp2xvx= X^n V_mu X^m for each side
+      #This calculates nmp2xvx= X^n V_mu X^m for each side
       nmp2xvx = einsum('na,pab,mb->nmp', xna, v_pab, xmb, optimize=optimize)
+
       for iw,si0 in enumerate(wpq2si0):
         # This calculates nmp2xvx(outer loop)*real.W_mu_nu*nmp2xvx 
         nmw2sf[:,:,iw] = einsum('nmp,pq,nmq->nm', nmp2xvx, si0, nmp2xvx, optimize=optimize)

--- a/pyscf/nao/gw.py
+++ b/pyscf/nao/gw.py
@@ -10,6 +10,7 @@ from pyscf.nao.log_mesh import funct_log_mesh
 from pyscf.data.nist import HARTREE2EV
 from pyscf.nao.m_valence import get_str_fin
 from timeit import default_timer as timer
+import time
 from numpy import stack, dot, zeros, einsum, pi, log, array, require
 import scipy.sparse as sparse
 from pyscf.nao import scf
@@ -30,6 +31,7 @@ class gw(scf):
     """ Constructor G0W0 class """
     # how to exclude from the input the dtype and xc_code ?
 
+    self.start_time = time.time()
     self.time_gw = np.zeros(24)
     self.time_gw[0] = timer();
     
@@ -476,7 +478,8 @@ class gw(scf):
     self.xc_code = 'GW'
     if self.verbosity>4:
       print(__name__,'\t\t====> Performed xc_code: {}\n '.format(self.xc_code))
-      print('\nConverged GW-corrected eigenvalues:\n',self.mo_energy_gw*HARTREE2EV)
+      print('\nConverged GW-corrected eigenvalues (Ha):\n',
+        [self.mo_energy_gw[0,s][self.start_st[s]:self.finish_st[s]] for s in range(self.nspin)])
 
     if self.write_R:    self.write_data()
     

--- a/pyscf/nao/gw.py
+++ b/pyscf/nao/gw.py
@@ -32,7 +32,7 @@ class gw(scf):
     # how to exclude from the input the dtype and xc_code ?
 
     self.start_time = time.time()
-    self.time_gw = np.zeros(24)
+    self.time_gw = np.zeros(28)
     self.time_gw[0] = timer();
     
     scf.__init__(self, **kw)
@@ -445,7 +445,7 @@ class gw(scf):
     self.mo_coeff_gw = np.copy(self.mo_coeff)
     self.argsort = []
 
-    self.time_gw[20] = timer();
+    self.time_gw[24] = timer();
     for s,nn in enumerate(self.nn):
       self.mo_energy_gw[0,s,nn] = self.sn2eval_gw[s]
       nn_occ = [n for n in nn if n<self.nocc_0t[s]]
@@ -467,7 +467,7 @@ class gw(scf):
       self.mo_energy_gw[0,s,:] = np.sort(self.mo_energy_gw[0,s,:])
       for n,m in enumerate(argsrt): self.mo_coeff_gw[0,s,n] = self.mo_coeff[0,s,m]
  
-    self.time_gw[21] = timer();
+    self.time_gw[25] = timer();
     self.xc_code = 'GW'
     if self.verbosity>4:
       print(__name__,'\t\t====> Performed xc_code: {}\n '.format(self.xc_code))
@@ -482,7 +482,7 @@ class gw(scf):
   
 
   def etot_gw(self):
-    self.time_gw[22] = timer();
+    self.time_gw[26] = timer();
     dm1 = self.make_rdm1()
     ecore = (self.get_hcore()*dm1[0,...,0]).sum()
     
@@ -500,7 +500,7 @@ class gw(scf):
         ecorr -= 0.5*m2occ[m]*(n2egw[n]-m2emf[m])
     
     self.etot_gw = etot+ecorr+self.energy_nuc()
-    self.time_gw[23] = timer();
+    self.time_gw[27] = timer();
     return self.etot_gw
     
   def spin_square(self):
@@ -533,7 +533,7 @@ class gw(scf):
   def write_data(self):
     "writes data in RESTART'hdf5' format"
     from pyscf.nao.m_restart import write_rst_h5py
-    write_rst_h5py (value='screened_interactions', data=self.snmw2sf)
+    write_rst_h5py (value='screened_interactions_f', data=self.snmw2sf)
     write_rst_h5py (value='MF_energies_Ha', data=self.mo_energy)
     write_rst_h5py (value='QP_energies_Ha', data=self.mo_energy_gw)
     write_rst_h5py (value='correct_order' , data=self.argsort)

--- a/pyscf/nao/gw.py
+++ b/pyscf/nao/gw.py
@@ -538,3 +538,5 @@ class gw(scf):
     write_rst_h5py (value='QP_energies_Ha', data=self.mo_energy_gw)
     write_rst_h5py (value='correct_order' , data=self.argsort)
     write_rst_h5py (value='G0W0_eigenfuns', data=self.mo_coeff_gw)
+    write_rst_h5py (value='K_matrix', data=self.kmat)
+    write_rst_h5py (value='J_matrix', data=self.jmat)

--- a/pyscf/nao/gw_iter.py
+++ b/pyscf/nao/gw_iter.py
@@ -115,7 +115,7 @@ class gw_iter(gw):
         6- using sparse dominant product basis
     """
 
-    algol = algo.lower() if algo is not None else 'dp_coo'  
+    algol = algo.lower() if algo is not None else 'ac_blas'  
     print("gw_xvx algo: ", algol)
 
     # 1-direct multiplication with np and einsum
@@ -149,18 +149,17 @@ class gw_iter(gw):
         xvx = gw_xvx_dp(self)
 
     # 6-dominant product basis with scipy sparse COO format
+    elif algol=='dp_coo':
+
+        from pyscf.nao.m_gw_xvx import gw_xvx_dp_ndcoo
+        xvx = gw_xvx_dp_ndcoo(self)
+
+    # 7-using sparcity of dominant product basis and Numba library
     elif algol=='dp_sparse':
 
         from pyscf.nao.m_gw_xvx import gw_xvx_dp_sparse
         xvx = gw_xvx_dp_sparse(self)
 
-    elif algol=='check':
-        ref = self.gw_xvx(algo='simple')
-        for s in range(self.nspin):
-            print('Spin {}, atom-centered with ref: {}'.format(s+1,np.allclose(ref[s],self.gw_xvx(algo='ac')[s],atol=1e-15)))
-            print('Spin {}, atom-centered (BLAS) with ref: {}'.format(s+1,np.allclose(ref[s],self.gw_xvx(algo='blas')[s],atol=1e-15)))
-            print('Spin {}, dominant product with ref: {}'.format(s+1,np.allclose(ref[s],self.gw_xvx(algo='dp')[s],atol=1e-15)))
-            print('Spin {}, sparse_dominant product-ndCoo with ref: {}'.format(s+1,np.allclose(ref[s], self.gw_xvx(algo='dp_coo')[s], atol=1e-15)))
     else:
       raise ValueError("Unknow algo {}".format(algol))
 
@@ -186,7 +185,7 @@ class gw_iter(gw):
     from scipy.sparse import csc_matrix
     import scipy.sparse.linalg as spla 
 
-    omega = 1j*20.0 if omega is None else omega
+    omega = 1j*10.0 if omega is None else omega
 
     #rf0 = self.rf0(ww = [omega])
     #veff = np.ones(self.nprod, dtype=self.dtypeComplex)

--- a/pyscf/nao/m_gw_xvx.py
+++ b/pyscf/nao/m_gw_xvx.py
@@ -111,7 +111,7 @@ def gw_xvx_ac_sparse(self):
         t2 = timer()
 
         if self.verbosity>3:
-            print("Get AC vertex timing: ", t2-t1)
+            print("Get AC vertex timing: ", round(t2-t1,3))
             print("Vpab.shape: ", self.v_pab.shape)
             print("Vpab.nnz: ", self.v_pab.nnz)
 
@@ -194,3 +194,89 @@ def gw_xvx_dp_sparse(self):
         print("cc_da.nnz: ", self.cc_da.nnz)
 
     return gw_xvx_sparse_dp(self)
+
+
+
+def gw_xvx_dp_ndcoo (self):
+
+    from pyscf.nao import ndcoo
+    xvx = []
+    size = self.cc_da.shape[0]
+    v_pd  = self.pb.get_dp_vertex_array()
+    c = self.pb.get_da2cc_den()
+    #First step
+    data = v_pd.ravel() #v_pd.reshape(-1)
+    #i0,i1,i2 = np.mgrid[0:v_pd.shape[0],0:v_pd.shape[1],0:v_pd.shape[2] ].reshape((3,data.size))   #fails in memory
+    i0,i1,i2 = np.ogrid[0:v_pd.shape[0],0:v_pd.shape[1],0:v_pd.shape[2]]
+    i00,i11,i22 = np.asarray(np.broadcast_arrays(i0,i1,i2)).reshape((3,data.size))
+
+    nc = ndcoo((data, (i00, i11, i22)))
+    m0 = nc.tocoo_pa_b('p,a,b->ap,b')
+
+    for s in range(self.nspin):
+        xna = self.mo_coeff[0,s,self.nn[s],:,0]
+        xmb = self.mo_coeff[0,s,:,:,0]
+        vx1 = m0*(xmb.T)
+        #Second Step
+        vx1 = vx1.reshape(size,self.norbs,self.norbs)   #shape (p,a,b)
+        vx_ref = vx1.reshape(self.norbs,-1)             #shape (b,p*a)
+        #data = vx1.ravel()
+        #i00,i11,i22 = np.asarray(np.broadcast_arrays(i0,i1,i2)).reshape((3,data.size))
+        #nc1 = ndcoo((data, (i00, i11, i22)))
+        #m1 = nc1.tocoo_pa_b('p,a,b->ap,b')  
+        #Third Step
+        xvx3 = xna.dot(vx_ref)                               #xna(ns,a).V(a,p*b)=xvx(ns,p*b)
+        xvx3 = xvx3.reshape(len(self.nn[s]),size,self.norbs) #xvx(ns,p,b)
+        xvx3 = np.swapaxes(xvx3,1,2)                         #xvx(ns,b,p)
+        xvx3 = xvx3.dot(c)                                #XVX=xvx.c
+        xvx.append(xvx3)
+
+    return xvx
+
+
+if __name__=='__main__':
+    from pyscf import gto, scf
+    from pyscf.nao import gw_iter  
+    from timeit import default_timer as timer 
+    import numpy as np
+
+    mol = gto.M(atom='''O 0.0, 0.0, 0.622978 ; O 0.0, 0.0, -0.622978''', basis='ccpvtz',spin=2)
+    mf = scf.UHF(mol)
+    mf.kernel()
+
+    gw = gw_iter(mf=mf, gto=mol)
+    timing = np.zeros(6)
+    t1 = timer()
+    ref = gw.gw_xvx(algo='simple')
+    t2 = timer()
+    timing[0] += round(t2-t1,3)
+    t1 = timer()
+    ac = gw.gw_xvx(algo='ac')
+    t2 = timer()
+    timing[1] += round(t2-t1,3)
+    t1 = timer()
+    ac_blas = gw.gw_xvx(algo='ac_blas')
+    t2 = timer()
+    timing[2] += round(t2-t1,3)
+    t1 = timer()
+    #ac_sparse= gw.gw_xvx(algo='ac_sparse')
+    t2 = timer()
+    timing[3] += round(t2-t1,3)
+    t1 = timer()
+    dp= gw.gw_xvx(algo='dp')
+    t2 = timer()
+    timing[4] += round(t2-t1,3)
+    t1 = timer()
+    dp_coo= gw.gw_xvx(algo='dp_coo')
+    t2 = timer()
+    timing[5] += round(t2-t1,3)
+    t1 = timer()
+    #dp_sparse= gw.gw_xvx(algo='dp_sparse')
+
+    for s in range(gw.nspin):
+            print('Spin {}, atom-centered with ref                  : {}, timing {} sec'.format(s+1,np.allclose(ref[s],ac[s],atol=1e-15),timing[1]))
+            print('Spin {}, atom-centered (BLAS) with ref           : {}, timing {} sec'.format(s+1,np.allclose(ref[s],ac_blas[s],atol=1e-15),timing[2]))
+            #print('Spin {}, sparse atom-centered with ref          : {}, timing {} sec'.format(s+1,np.allclose(ref[s],ac_sparse[s],atol=1e-15),timing[3]))
+            print('Spin {}, dominant product with ref               : {}, timing {} sec'.format(s+1,np.allclose(ref[s],dp[s],atol=1e-15),timing[4]))
+            print('Spin {}, sparse_dominant product-ndCoo with ref  : {}, timing {} sec'.format(s+1,np.allclose(ref[s],dp_coo[s],atol=1e-15),timing[5]))
+            #print('Spin {}, sparse_dominant product-numba with ref : {}, timing {} sec'.format(s+1,np.allclose(ref[s],dp_sparse[s],atol=1e-15)))

--- a/pyscf/nao/m_report.py
+++ b/pyscf/nao/m_report.py
@@ -90,8 +90,12 @@ def report_mfx(self, dm1=None):
     exp_co = np.zeros((self.nspin, self.norbs))
     exp_x = np.zeros((self.nspin, self.norbs))
     exp_f = np.zeros((self.nspin, self.norbs))
+
+    if not hasattr(self, 'kmat'):
+        self.kmat = self.get_k()
+
     if self.nspin==1:
-        x = -0.5* self.get_k()
+        x = -0.5* self.kmat
         mat_h = np.dot(self.mo_coeff[0,0,:,:,0], H)   
         exp_h = np.einsum('nb,nb->n', mat_h, self.mo_coeff[0,0,:,:,0])
         mat_co = np.dot(self.mo_coeff[0,0,:,:,0], co)  
@@ -109,7 +113,7 @@ def report_mfx(self, dm1=None):
         EX = 0.5*(x*dm1).sum()
 
     elif self.nspin==2:
-        x = -self.get_k()
+        x = -self.kmat
         cou = co[0]+co[1]
         Vha = 0.5*(cou*dm1).sum()
         for s in range(self.nspin):
@@ -163,8 +167,11 @@ def sigma_xc(self):
     mat1 is product of this operator and molecular coefficients and it will be diagonalized in expval by einsum
     Sigma_c = E_GW - E_HF
     """
+    if not hasattr(self, 'kmat'):
+        self.kmat = self.get_k()
+
     if self.nspin==1:
-      mat = -0.5*self.get_k()
+      mat = -0.5*self.kmat
       mat1 = np.dot(self.mo_coeff[0,0,:,:,0], mat)
       expval = np.einsum('nb,nb->n', mat1, self.mo_coeff[0,0,:,:,0]).reshape((1,self.norbs))
       print('===| Expectationvalues of Exchange energy(eV) |===\n %3s  %16s  %3s'%('no.','<Sigma_x> ','occ'))
@@ -172,7 +179,7 @@ def sigma_xc(self):
         if (i==self.nfermi[0]): print('-'*50)
         print (' %3d  %16.6f  %3d'%(i,a[0], b[0]))
     elif self.nspin==2:
-      mat = -self.get_k()
+      mat = -self.kmat
       expval = np.zeros((self.nspin, self.norbs))
       for s in range(self.nspin):
         mat1 = np.dot(self.mo_coeff[0,s,:,:,0], mat[s])

--- a/pyscf/nao/m_report.py
+++ b/pyscf/nao/m_report.py
@@ -64,9 +64,12 @@ def report_gw (self):
                 out_file.write("\nWarning: Spin {}, swapping in QP orbital energies has happened!".format(s+1))
                 print('Energy-sorted MO indices: \t {}'.format(swap))                
                 out_file.write('\nEnergy-sorted MO indices: \t {}'.format(swap))
-        elapsed_time = time.time() - start_time
-        print('\nTotal running time is: {}\nJOB DONE! \t {}'.format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time)),time.strftime("%c")))
-        out_file.write('\nTotal running time is: {}\nJOB DONE! \t {}'.format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time)),time.strftime("%c"))) 
+
+        print('\n=====| Timings of main algorithms |=====')
+        report_gw_t(self)
+        out_file.write('\nTotal spent time :{:14.2f} secs'.format (self.time_gw[-1]-self.time_gw[0]))
+        print('\nJOB DONE! \t {}'.format(time.strftime("%c")))
+        out_file.write('\nJOB DONE! \t {}'.format(time.strftime("%c"))) 
         out_file.close
 
 
@@ -104,7 +107,7 @@ def report_mfx(self, dm1=None):
         exp_x = np.einsum('nb,nb->n', mat_x, self.mo_coeff[0,0,:,:,0])
         mat_f = np.dot(self.mo_coeff[0,0,:,:,0], fock)
         exp_f = np.einsum('nb,nb->n', mat_f, self.mo_coeff[0,0,:,:,0])
-        print('='*20,'| Restricted HF expectation values (eV) |','='*20)
+        print('\n','='*20,'| Restricted HF expectation values (eV) |','='*20)
         print('%2s  %13s  %13s  %13s  %13s  %13s  %3s'%('no.','<H_core>','<K>  ','<Sigma_x>','Fock   ','MF energy ','occ'))
         for i, (a,b,c,d,e,f) in enumerate(zip(exp_h.T*HARTREE2EV,exp_co.T*HARTREE2EV, exp_x.T*HARTREE2EV,exp_f.T*HARTREE2EV,self.mo_energy.T*HARTREE2EV, self.mo_occ[0].T)):   
           if (i==self.nfermi[0]): print('-'*83)
@@ -125,7 +128,7 @@ def report_mfx(self, dm1=None):
           exp_x[s] = np.einsum('nb,nb->n', mat_x, self.mo_coeff[0,s,:,:,0])
           mat_f = np.dot(self.mo_coeff[0,s,:,:,0], fock[s])
           exp_f[s] = np.einsum('nb,nb->n', mat_f, self.mo_coeff[0,s,:,:,0])
-        print('='*59,'| Unrestricted HF expectation values (eV) |','='*60)
+        print('\n','='*59,'| Unrestricted HF expectation values (eV) |','='*60)
         print('%2s  %13s  %13s  %13s  %13s  %13s  %3s |%13s  %13s  %13s  %13s  %13s  %3s '%('no.','<H_core>','<K>  ','<Sigma_x>','Fock   ','MF energy ','occ','<H_core>','<K>   ','<Sigma_x>','Fock  ','MF energy','occ'))
         for i , (a,b,c,d,e,f) in enumerate(zip(exp_h.T*HARTREE2EV,exp_co.T*HARTREE2EV, exp_x.T*HARTREE2EV,exp_f.T*HARTREE2EV,self.mo_energy.T*HARTREE2EV, self.mo_occ[0].T)):
           if (i==self.nfermi[0] or i==self.nfermi[1]): print('-'*163)
@@ -201,8 +204,22 @@ def sigma_xc(self):
             for i , (a,b) in enumerate(zip(sigma_gw_c.T* HARTREE2EV,self.mo_occ[0].T)):
                 if (i==self.nfermi[0] or i==self.nfermi[1]): print('-'*60)
                 print(' %3d  %16.6f  %3d  | %13.6f  %3d'%(i, a[0],b[0],a[1], b[1]))
-            
-        
+ 
+
+def report_gw_t(self):
+    """Lists spent time within main GW calculation"""
+    steps = ['initialize NAO',                         #01
+             'get_h0_vh_x_expval',' 1-get_K', ' 2-get_J',#23-45-67
+             'G0W0_eigvals','  1-snmw2sf','   1-1-XVX','   1-2-chi_0', #89-1011-1213-1415
+                            '  2-corr_int_tot',        #1617
+                            '  3-corr_res_tot',        #1819
+             'scissor',                                #2021
+             'etot_gw']                                #2223
+
+    timing = list(self.time_gw[1::2]- self.time_gw[0:-1:2])
+    for i in zip(timing,steps):     
+      if (round(i[0],3) != 0): print('{:20.19s}:{:14.2f} secs'.format(i[1],i[0]))
+    print('-'*20,'\nTotal spent time    :{:14.2f} secs'.format (self.time_gw[-1]-self.time_gw[0]),'\n')       
 
 #
 # Example of reporting expectation values of mean-field calculations.

--- a/pyscf/nao/m_report.py
+++ b/pyscf/nao/m_report.py
@@ -65,7 +65,7 @@ def report_gw (self):
                 out_file.write('\nEnergy-sorted MO indices: \t {}'.format(swap))
 
         out_file.write('\n=====| Timings of main algorithms |=====')
-        timing, steps = report_gw_t(self)
+        timing, steps = report_gw_t(self,ret=True)
 
         for i in zip(timing, steps):     
             if (round(i[0],3) != 0): out_file.write('\n{:20.19s}:{:14.2f} secs'.format(i[1],i[0]))
@@ -211,7 +211,7 @@ def sigma_xc(self):
                 print(' %3d  %16.6f  %3d  | %13.6f  %3d'%(i, a[0],b[0],a[1], b[1]))
  
 
-def report_gw_t(self):
+def report_gw_t(self, ret=None):
     """Lists spent time within main GW calculation"""
     steps = ['initialize NAO',                         #01
              'get_h0_vh_x_expval',' 1-get_K', ' 2-get_J',#23-45-67
@@ -228,7 +228,8 @@ def report_gw_t(self):
       if (round(i[0],3) != 0): print('{:20.19s}:{:14.2f} secs'.format(i[1],i[0]))
 
     print('-'*20,'\nTotal spent time    :{:14.2f} secs'.format (self.time_gw[-1]-self.time_gw[0]),'\n')
-    return  timing, steps      
+    if ret:
+        return  timing, steps      
 
 #
 # Example of reporting expectation values of mean-field calculations.

--- a/pyscf/nao/m_report.py
+++ b/pyscf/nao/m_report.py
@@ -64,10 +64,14 @@ def report_gw (self):
                 print('Energy-sorted MO indices: \t {}'.format(swap))                
                 out_file.write('\nEnergy-sorted MO indices: \t {}'.format(swap))
 
-        print('\n=====| Timings of main algorithms |=====')
-        report_gw_t(self)
+        out_file.write('\n=====| Timings of main algorithms |=====')
+        timing, steps = report_gw_t(self)
+
+        for i in zip(timing, steps):     
+            if (round(i[0],3) != 0): out_file.write('\n{:20.19s}:{:14.2f} secs'.format(i[1],i[0]))
+
         elapsed_time = self.time_gw[-1]-self.time_gw[0]
-        out_file.write('\nTotal spent time :{:14.2f} secs'.format (elapsed_time))
+        out_file.write('\n'+'-'*20+'\nTotal spent time    :{:14.2f} secs\n'.format (elapsed_time))
         finish_t =  elapsed_time + self.start_time
         print('\nJOB DONE! \t {}'.format(time.strftime("%c", time.localtime(finish_t))))
         out_file.write('\nJOB DONE! \t {}'.format(time.strftime("%c", time.localtime(finish_t))))
@@ -213,15 +217,18 @@ def report_gw_t(self):
              'get_h0_vh_x_expval',' 1-get_K', ' 2-get_J',#23-45-67
              'G0W0_eigvals','  1-snmw2sf','   1-1-XVX','   1-2-chi_0', #89-1011-1213-1415
                             '  2-corr_int_tot',        #1617
-                            '  3-corr_res_tot',        #1819
-             'scissor',                                #2021
-             'etot_gw']                                #2223
+                            '  3-corr_res_tot','   3-1-chi_0',        #1819-2021
+                            '  4-veffmatvec',          #2223
+             'scissor',                                #2425
+             'etot_gw']                                #2627
 
     timing = list(self.time_gw[1::2]- self.time_gw[0:-1:2])
+    print('\n=====| Timings of main algorithms |=====')
     for i in zip(timing, steps):     
       if (round(i[0],3) != 0): print('{:20.19s}:{:14.2f} secs'.format(i[1],i[0]))
 
-    print('-'*20,'\nTotal spent time    :{:14.2f} secs'.format (self.time_gw[-1]-self.time_gw[0]),'\n')       
+    print('-'*20,'\nTotal spent time    :{:14.2f} secs'.format (self.time_gw[-1]-self.time_gw[0]),'\n')
+    return  timing, steps      
 
 #
 # Example of reporting expectation values of mean-field calculations.

--- a/pyscf/nao/m_report.py
+++ b/pyscf/nao/m_report.py
@@ -1,9 +1,7 @@
 from __future__ import print_function, division
 import numpy as np
 from pyscf.data.nist import HARTREE2EV
-import time
-
-start_time = time.time()
+import time, socket, getpass
 
 def report_gw (self):
     """ Prints the energy levels of mean-field and G0W0"""
@@ -19,7 +17,8 @@ def report_gw (self):
     egwev = self.mo_energy_gw[0].T * HARTREE2EV
     file_name= ''.join(self.get_symbols())
     with open('report_'+file_name+'.out','w') as out_file:
-        out_file.write('Job started at {}, on {}.\n'.format(time.strftime("%H:%M:%S", time.gmtime(start_time)),time.strftime("%c")))
+        out_file.write('Job started on {}, @ {}-{}.\n'.format(time.strftime("%c",
+             time.localtime(self.start_time)), socket.gethostname(), getpass.getuser()))
         out_file.write('='*35+'| INPUT file |'+'='*35+'\n'+inp+'\n'+'='*85+'\n')
         if self.nspin==1:
             print('\n','='*50,'\n','='*12,'|G0W0 eigenvalues (eV)|','='*13,'\n','='*50)
@@ -67,9 +66,11 @@ def report_gw (self):
 
         print('\n=====| Timings of main algorithms |=====')
         report_gw_t(self)
-        out_file.write('\nTotal spent time :{:14.2f} secs'.format (self.time_gw[-1]-self.time_gw[0]))
-        print('\nJOB DONE! \t {}'.format(time.strftime("%c")))
-        out_file.write('\nJOB DONE! \t {}'.format(time.strftime("%c"))) 
+        elapsed_time = self.time_gw[-1]-self.time_gw[0]
+        out_file.write('\nTotal spent time :{:14.2f} secs'.format (elapsed_time))
+        finish_t =  elapsed_time + self.start_time
+        print('\nJOB DONE! \t {}'.format(time.strftime("%c", time.localtime(finish_t))))
+        out_file.write('\nJOB DONE! \t {}'.format(time.strftime("%c", time.localtime(finish_t))))
         out_file.close
 
 
@@ -147,7 +148,7 @@ def report_mfx(self, dm1=None):
             ss = self.mf.spin_square()
             print('<S^2> and  2S+1                  :%16.7f %16.7f'%(ss[0],ss[1]))
             print('Instead of                       :%16.7f %16.7f'%(s_ref, 2*sp+1))
-    elapsed_time = time.time() - start_time
+    elapsed_time = time.time() - self.start_time
     print('\nMean-field running time is: {}'.format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time))))
     #sys.stdout.close()
 
@@ -217,8 +218,9 @@ def report_gw_t(self):
              'etot_gw']                                #2223
 
     timing = list(self.time_gw[1::2]- self.time_gw[0:-1:2])
-    for i in zip(timing,steps):     
+    for i in zip(timing, steps):     
       if (round(i[0],3) != 0): print('{:20.19s}:{:14.2f} secs'.format(i[1],i[0]))
+
     print('-'*20,'\nTotal spent time    :{:14.2f} secs'.format (self.time_gw[-1]-self.time_gw[0]),'\n')       
 
 #

--- a/pyscf/nao/m_restart.py
+++ b/pyscf/nao/m_restart.py
@@ -6,7 +6,7 @@
 from __future__ import division
 import numpy as np
 
-def read_rst_h5py (value, filename=None):
+def read_rst_h5py (value, filename=None, arr=None):
     import h5py ,os
     if filename is None: 
         msg = "No file to open"
@@ -22,7 +22,7 @@ def read_rst_h5py (value, filename=None):
     a_group_key = list(fl.keys())
     if value in a_group_key: 
         # Get the data
-        data = list(fl[value])
+        data = np.asarray(fl[value]) if arr else list(fl[value])
         msg = 'RESTART: matrix elements of {} was read from {}'.format(value, filename)
         return data, msg
 
@@ -31,7 +31,7 @@ def write_rst_h5py(data, value, filename = None):
     import h5py
     if filename is None: 
       filename= 'RESTART.hdf5'   
-
+    
     hf = h5py.File(filename, 'a')
     try:
         hf.create_dataset(value, data=data)
@@ -67,6 +67,11 @@ def read_rst_yaml (filename=None):
             return data, msg
         except yaml.YAMLError as exc:
             return exc
+
+def check_res (filename):
+    import os
+    if (filename == find(filename,'./')):
+        os.rename(filename, filename+'_OLD')
 
 def find (pattern, path):
     import os, fnmatch

--- a/pyscf/nao/test/test2html.sh
+++ b/pyscf/nao/test/test2html.sh
@@ -74,8 +74,8 @@ mutt -e 'set content_type="text/html"' "$EMAIL" -s "$SUBJECT" <"$EMAILMESSAGE"
 
 
 #moving data to home
-mkdir REPORT
-mv *.html ./REPORT/
-mv REPORT $HOME/
+#mkdir REPORT
+#mv *.html ./REPORT/
+#mv REPORT $HOME/
 
 git clean -f

--- a/pyscf/nao/test/test2html.sh
+++ b/pyscf/nao/test/test2html.sh
@@ -27,7 +27,7 @@ echo "${white}"
 #git pull https://github.com/cfm-mpc/pyscf nao
 
 
-LIST="$(ls test_*.py)"
+LIST="$(ls test_*gw*.py)"
 err=("${arr[@]}")
 m=0
 n=0


### PR DESCRIPTION
Hi @kovalp @marc,
Hope you are doing well. This request includes 3 changes:
1- as you know within the QP correction `g0w0_eigvals_iter`, both integral `gw_corr_int_iter(sn2w)` and residues `gw_corr_res_iter(sn2w)` will be iterated to achieve convergence. I found often one of them converges sooner and therefore should not send in the next iteration. e.g in Anthracene this leads to saving 5% of total runtime when residue part converged 3 iterations sooner.
2- adds initial guess to `gw_corr_res_iter` function. Despite it is led to worse timing in Anthracene, I am trying with a larger system!
3- improves the reports and prints by adding better timing for the main algos in GW classes.