### PR TITLE
Krylov solver

### DIFF
--- a/pyscf/nao/bse_iter.py
+++ b/pyscf/nao/bse_iter.py
@@ -191,15 +191,13 @@ class bse_iter(gw):
         The operator (1 - K L0) is named self.sext2seff_matvec """
     
     from scipy.sparse.linalg import LinearOperator
-    from scipy.sparse.linalg import lgmres as gmres_alias
-    #from spipy.sparse.linalg import gmres as gmres_alias
     nsnn = self.nspin*self.norbs2
     assert sext.size==nsnn
     
     self.comega_current = comega
     op = LinearOperator((nsnn,nsnn), matvec=self.sext2seff_matvec, dtype=self.dtypeComplex)
     sext_shape = np.require(sext.reshape(nsnn), dtype=self.dtypeComplex, requirements='C')
-    resgm,info = gmres_alias(op, sext_shape, tol=self.tddft_iter_tol)
+    resgm,info = self.krylov_solver(op, sext_shape, **self.krylov_options)
     return (resgm.reshape(-1),info)
 
   def sext2seff_matvec(self, sab):

--- a/pyscf/nao/chi0_matvec.py
+++ b/pyscf/nao/chi0_matvec.py
@@ -5,6 +5,7 @@ from numpy import array, argmax
 from scipy.sparse import csr_matrix, coo_matrix
 from timeit import default_timer as timer
 from scipy.linalg import blas
+import scipy.sparse.linalg as splin
 
 from pyscf.nao import mf
 from pyscf.nao.m_chi0_noxv import chi0_mv_gpu, chi0_mv
@@ -22,6 +23,27 @@ class chi0_matvec(mf):
             self.use_initial_guess_ite_solver = kw["use_initial_guess_ite_solver"]
         else:
             self.use_initial_guess_ite_solver = False
+
+        krylov_solvers = {"lgmres": splin.lgmres,
+                          "gmres": splin.gmres,
+                          "gcrotmk": splin.gcrotmk,
+                          "qmr": splin.qmr,
+                          "minres": splin.minres,
+                          "bicgstab": splin.bicgstab,
+                          "bicg": splin.bicg,
+                          "cg": splin.cg,
+                          "cgs": splin.cgs}
+        if "krylov_solver" in kw:
+            self.krylov_solver = krylov_solvers[kw["krylov_solver"]]
+        else:
+            self.krylov_solver = krylov_solvers["lgmres"]
+
+        if "krylov_options" in kw:
+            self.krylov_options = kw["krylov_options"]
+        else:
+            self.krylov_options = {"tol": 1.0e-3,
+                                   "atol": 1.0e-3,
+                                   "maxiter": 1000}
 
         mf.__init__(self, **kw)
 

--- a/pyscf/nao/gw_iter.py
+++ b/pyscf/nao/gw_iter.py
@@ -37,8 +37,6 @@ class gw_iter(gw):
   def __init__(self, **kw):
     gw.__init__(self, **kw)
 
-    self.gw_iter_tol = kw['gw_iter_tol'] if 'gw_iter_tol' in kw else 1e-4
-    self.maxiter = kw['maxiter'] if 'maxiter' in kw else 1000
     self.gw_xvx_algo = kw['gw_xvx_algo'] if 'gw_xvx_algo' in kw else "ac_blas"
     self.use_preconditioner = kw['use_preconditioner'] if 'use_preconditioner' in kw else False
 
@@ -63,7 +61,7 @@ class gw_iter(gw):
     This computes the correlation part of the screened interaction using LinearOpt and lgmres
     lgmres method is much slower than np.linalg.solve !!
     """
-    from scipy.sparse.linalg import lgmres, LinearOperator 
+    from scipy.sparse.linalg import LinearOperator 
     si0 = np.zeros((ww.size, self.nprod, self.nprod), dtype=self.dtypeComplex)
     k_c_opt = LinearOperator((self.nprod,self.nprod), matvec=self.gw_vext2veffmatvec, dtype=self.dtypeComplex) 
     for iw,w in enumerate(ww):                                 
@@ -73,8 +71,8 @@ class gw_iter(gw):
         k_c = self.kernel_sq[m] 
         b = self.chi0_mv(k_c, self.comega_current) 
         a = self.kernel_sq.dot(b) 
-        si0[iw,m,:],exitCode = lgmres(k_c_opt, a, atol=self.gw_iter_tol, maxiter=self.maxiter)    
-        if exitCode != 0: print("LGMRES has not achieved convergence: exitCode = {}".format(exitCode))
+        si0[iw,m,:],exitCode = self.krylov_solver(k_c_opt, a, **self.krylov_options)    
+        if exitCode != 0: print("Krylov has not achieved convergence: exitCode = {}".format(exitCode))
     return si0
 
   def si_c_check (self, tol = 1e-5):
@@ -220,7 +218,7 @@ class gw_iter(gw):
     """
 
 
-    from scipy.sparse.linalg import LinearOperator, lgmres
+    from scipy.sparse.linalg import LinearOperator
 
     if self.GPU:
         self.initialize_chi0_matvec_GPU()
@@ -296,13 +294,12 @@ class gw_iter(gw):
                                     x0 = None
                                 else:
                                     x0 = copy.deepcopy(prev_sol[n, m, :])
-                            sf_aux[n,m,:], exitCode = lgmres(k_c_opt, a,
-                                                              atol=self.gw_iter_tol,
-                                                              maxiter=self.maxiter,
-                                                              x0=x0, M=M0)
+                            sf_aux[n,m,:], exitCode = \
+                                    self.krylov_solver(k_c_opt, a, x0=x0, M=M0,
+                                                       **self.krylov_options)
  
                             if exitCode != 0:
-                              print("LGMRES has not achieved convergence: exitCode = {}".format(exitCode))
+                              print("Krylov solver has not achieved convergence: exitCode = {}".format(exitCode))
                 
 
             t2 = timer()
@@ -378,12 +375,10 @@ class gw_iter(gw):
                              matvec=self.gw_vext2veffmatvec,
                              dtype=self.dtypeComplex)
 
-    from scipy.sparse.linalg import lgmres
-    resgm, info = lgmres(veff_op,
-                         np.require(vext, dtype=self.dtypeComplex, requirements='C'),
-                         atol=self.gw_iter_tol, maxiter=self.maxiter)
+    b = np.require(vext, dtype=self.dtypeComplex, requirements='C')
+    resgm, info = self.krylov_solver(veff_op, b, **self.krylov_options)
     if info != 0:
-      print("LGMRES has not achieved convergence: exitCode = {}".format(info))
+      print("Krylov solver has not achieved convergence: exitCode = {}".format(info))
     return resgm
 
   def check_veff(self, optimize="greedy"):
@@ -471,7 +466,7 @@ class gw_iter(gw):
     iterative procedure
     """
     
-    from scipy.sparse.linalg import lgmres, LinearOperator
+    from scipy.sparse.linalg import LinearOperator
 
     if not hasattr(self, 'xvx'): self.xvx = self.gw_xvx(self.gw_xvx_algo)
 
@@ -507,10 +502,9 @@ class gw_iter(gw):
                 self.time_gw[21] += tt2 - tt1
                 a = self.kernel_sq.dot(b)
 
-                si_xvx, exitCode = lgmres(k_c_opt, a, atol=self.gw_iter_tol,
-                                          maxiter=self.maxiter)#, x0 = prev_sol, M=M0)
+                si_xvx, exitCode = self.krylov_solver(k_c_opt, a, **self.krylov_options)
                 if exitCode != 0:
-                    print("LGMRES has not achieved convergence: exitCode = {}".format(exitCode))
+                    print("Krylov solver has not achieved convergence: exitCode = {}".format(exitCode))
 
                 if self.use_initial_guess_ite_solver:
                     #if nl > 0: print('prev_sol ,si_xvx', (abs(prev_sol - si_xvx).sum()))
@@ -712,7 +706,7 @@ if __name__=='__main__':
     #gw_it = gw.get_snmw2sf_iter(nbnd)
 
     print('Comparison between matrix element of W obtained from gw_iter and gw classes: ', 
-            np.allclose(gw_it, gw_ref, atol= gw.gw_iter_tol)) 
+            np.allclose(gw_it, gw_ref, atol=1.0e-4)) 
     print([abs(gw_it[s]-gw_ref[s]).sum() for s in range(gw.nspin)])  
 
     sn2w = [np.copy(gw.ksn2e[0,s,nn]) for s,nn in enumerate(gw.nn)]
@@ -722,7 +716,7 @@ if __name__=='__main__':
     sn2r_ref = gw.gw_corr_res(sn2w)
     t3 = timer()
     print('Comparison between energies in residue part obtained from gw_iter and gw classes: ',
-            np.allclose(sn2r_it, sn2r_ref, atol= gw.gw_iter_tol))
+            np.allclose(sn2r_it, sn2r_ref, atol=1.0e-4))
     print([abs(sn2r_it[s]-sn2r_ref[s]).sum() for s in range(gw.nspin)])
     print('iter Vs. ref', t2-t1, t3-t2)
     #gw.kernel_gw_iter()

--- a/pyscf/nao/tddft_iter.py
+++ b/pyscf/nao/tddft_iter.py
@@ -19,18 +19,11 @@ class tddft_iter(chi0_matvec):
 
     Input Parameters:
     -----------------
-      kw: keywords arguments:
-          * tddft_iter_tol (real, default: 1e-3): tolerance to reach for 
-                          convergency in the iterative procedure.
-          * tmp_fname (string, default None): temporary file to save polarizability
-                          at each frequency. Can be a life saver for large systems.
     """
 
     def __init__(self, **kw):
 
         self.load_kernel = load_kernel = kw['load_kernel'] if 'load_kernel' in kw else False
-        self.maxiter = kw['maxiter'] if 'maxiter' in kw else 1000
-        self.tddft_iter_tol = kw['tddft_iter_tol'] if 'tddft_iter_tol' in kw else 1e-3
         self.res_method = kw["res_method"] if "res_method" in kw else "both"
 
         # better to check input before to initialize calculations
@@ -151,14 +144,11 @@ class tddft_iter(chi0_matvec):
         veff_op = splin.LinearOperator((nsp,nsp), matvec=self.vext2veff_matvec,
                                  dtype=self.dtypeComplex)
 
-        resgm, info = splin.lgmres(veff_op, np.require(vext, dtype=self.dtypeComplex,
-                                                 requirements='C'), x0=x0,
-                                   tol=self.tddft_iter_tol,
-                                   atol=self.tddft_iter_tol,
-                                   maxiter=self.maxiter)
+        b = np.require(vext, dtype=self.dtypeComplex, requirements='C')
+        resgm, info = self.krylov_solver(veff_op, b, x0=x0, **self.krylov_options)
 
         if info != 0:
-            print("LGMRES Warning: info = {0}".format(info))
+            print("Krylov Warning: info = {0}".format(info))
     
         return resgm
 

--- a/pyscf/nao/tddft_iter_2ord.py
+++ b/pyscf/nao/tddft_iter_2ord.py
@@ -38,28 +38,17 @@ class tddft_iter_2ord(tddft_iter):
      or computes 
            X = (1 - K chi0 K chi0 )^{-1} vext 
     """
-    from scipy.sparse.linalg import LinearOperator, lgmres
+    from scipy.sparse.linalg import LinearOperator
     assert len(vext)==len(self.moms0), "%r, %r "%(len(vext), len(self.moms0))
     self.comega_current = comega
-    veff2_op = LinearOperator((self.nprod,self.nprod), matvec=self.umkckc_mv, dtype=self.dtypeComplex)
+    veff2_op = LinearOperator((self.nprod,self.nprod),
+                              matvec=self.umkckc_mv, dtype=self.dtypeComplex)
 
-    if self.res_method == "absolute":
-        tol = 0.0
-        atol = self.tddft_iter_tol
-    elif self.res_method == "relative":
-        tol = self.tddft_iter_tol
-        atol = 0.0
-    elif self.res_method == "both":
-        tol = self.tddft_iter_tol
-        atol = self.tddft_iter_tol
-    else:
-        raise ValueError("Unknow res_method")
-
-    resgm,info = lgmres(veff2_op, np.require(vext, dtype=self.dtypeComplex,
-                                             requirements='C'), x0=x0, 
-                        tol=tol, atol=atol, maxiter=self.maxiter)
+    b = np.require(vext, dtype=self.dtypeComplex, requirements='C')
+    resgm,info = self.krylov_solver(veff2_op, b, x0=x0, **self.krylov_options)
     
-    if info != 0:  print("LGMRES Warning: info = {0}".format(info))
+    if info != 0:
+        print("Krylov solver Warning: info = {0}".format(info))
 
     return resgm
 

--- a/pyscf/nao/test/test_0055_gw_sf_iter.py
+++ b/pyscf/nao/test/test_0055_gw_sf_iter.py
@@ -20,7 +20,7 @@ class KnowValues(unittest.TestCase):
     sf_it = gwi.get_snmw2sf_iter()
     self.assertEqual(len(sf), len(sf_it))
     self.assertEqual(sf[0].shape, sf_it[0].shape)
-    self.assertTrue(np.allclose(sf, sf_it, atol = gwi.gw_iter_tol))
+    self.assertTrue(np.allclose(sf, sf_it, atol=1.0e-3))
     
     
 if __name__ == "__main__": unittest.main()

--- a/pyscf/nao/test/test_0055_gw_sf_iter_polarize.py
+++ b/pyscf/nao/test/test_0055_gw_sf_iter_polarize.py
@@ -14,16 +14,17 @@ class KnowValues(unittest.TestCase):
     mf.kernel()
 
     gw = gw_iter(mf=mf, gto=mol, verbosity=1, niter_max_ev=1, nff_ia=5, nvrt=1,
-                 nocc=1, gw_iter_tol=1e-04)
+                 nocc=1, krylov_solver="lgmres", krylov_options={"atol": 1e-04,
+                                                                 "tol": 1.0e-5})
 
     gw_it = gw.get_snmw2sf_iter()
     gw_ref = gw.get_snmw2sf()
-    self.assertTrue(np.allclose(gw_it, gw_ref, atol= gw.gw_iter_tol))
+    self.assertTrue(np.allclose(gw_it, gw_ref, atol=1.0e-4))
 
     sn2eval_gw = [np.copy(gw.ksn2e[0,s,nn]) for s,nn in enumerate(gw.nn) ]
     sn2r_it  = gw.gw_corr_res_iter(sn2eval_gw)
     sn2r_ref = gw.gw_corr_res(sn2eval_gw)
-    self.assertTrue(np.allclose(sn2r_it, sn2r_ref, atol= gw.gw_iter_tol))
+    self.assertTrue(np.allclose(sn2r_it, sn2r_ref, atol=1.0e-4))
     
     
 if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
use a generic method to call the scipy iterative solvers. This permit to easily switch solver (preliminary tests show that other solvers than lgmres may provide better performances).